### PR TITLE
Show locked modal when navigating to unavailable classes

### DIFF
--- a/frontend/src/components/organisms/Course.jsx
+++ b/frontend/src/components/organisms/Course.jsx
@@ -130,7 +130,12 @@ export const Course = () => {
   const passNextVideo = () => {
     const currentIndex = CLASSES.findIndex(v => v.id === activeVideo.id);
     if (currentIndex < CLASSES.length - 1) {
-      setActiveVideo(CLASSES[currentIndex + 1]);
+      const nextVideo = CLASSES[currentIndex + 1];
+      if (nextVideo.available) {
+        setActiveVideo(nextVideo);
+      } else {
+        setShowLockedModal(true);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- Display locked modal when 'Next' button selects an unavailable class

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Network error fetching posts: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689fac5f2f3083309d503d3b0750303c